### PR TITLE
Use the query string for search endpoint input

### DIFF
--- a/regcore_read/views/search_utils.py
+++ b/regcore_read/views/search_utils.py
@@ -30,7 +30,7 @@ def requires_search_args(view):
     @wraps(view)
     def wrapper(request, *args, **kwargs):
         try:
-            user_args = parser.parse(search_args, request)
+            user_args = parser.parse(search_args, request, location="query")
         except ValidationError as err:
             return user_error(err.messages)
         return view(request, *args, search_args=SearchArgs(**user_args),


### PR DESCRIPTION
Before this change the argument parser for the search endpoint looked for arguments in the `body` of the `request` formated a json (this is default behavior). The expected usage is to pass those arguments in the query string.